### PR TITLE
fix: remove c8 sub-package

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -29,7 +29,6 @@ const VITEST_SUB_PACKAGES = [
 	'snapshot',
 	'ui',
 	'web-worker',
-	'coverage-c8',
 	'coverage-v8',
 	'runner',
 	'spy',


### PR DESCRIPTION
- Fixes crash of https://github.com/vitest-dev/vitest-ecosystem-ci/actions/runs/6669372014/job/18127001663