### PR TITLE
ci: increase ci timeout

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -66,7 +66,7 @@ jobs:
             return comment.id
 
   execute-selected-suite:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: init
     if: "inputs.suite != '-'"
@@ -89,7 +89,7 @@ jobs:
           ${{ inputs.suite }}
 
   execute-all:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: init
     if: "inputs.suite == '-'"

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -43,7 +43,7 @@ on:
           - vitest-coverage-large
 jobs:
   execute-selected-suite:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -35,7 +35,7 @@ on:
     types: [ecosystem-ci]
 jobs:
   test-ecosystem:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
- `vitest-tests/coverage-large` may take longer than 30mins. This is intentional as it's large setup.