### PR TITLE
feat: add `vitest-tests/reporters-large`

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -36,6 +36,7 @@ on:
           - vitest-github-actions-reporter
           - vitest-browser-simple
           - vitest-coverage-large
+          - vitest-reporters-large
 jobs:
   init:
     runs-on: ubuntu-latest
@@ -103,6 +104,7 @@ jobs:
           - vitest-github-actions-reporter
           - vitest-browser-simple
           - vitest-coverage-large
+          - vitest-reporters-large
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -41,6 +41,7 @@ on:
           - vitest-github-actions-reporter
           - vitest-browser-simple
           - vitest-coverage-large
+          - vitest-reporters-large
 jobs:
   execute-selected-suite:
     timeout-minutes: 30

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -47,6 +47,7 @@ jobs:
           - vitest-github-actions-reporter
           - vitest-browser-simple
           - vitest-coverage-large
+          - vitest-reporters-large
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/tests/vitest-reporters-large.ts
+++ b/tests/vitest-reporters-large.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'vitest-tests/reporters-large',
+		beforeTest: ['pnpm cpu-profile'],
+		test: 'test',
+	})
+}


### PR DESCRIPTION
- Adds https://github.com/vitest-tests/reporters-large

`vitest@1.0.3` showing effects of https://github.com/vitest-dev/vitest/issues/4710

> ```
> Tests took 404.473283
> Top 5 slowest functions [
>   {
>     name: 'stringWidth at file:///home/runner/work/reporters-large/reporters-large/node_modules/.pnpm/vitest@1.0.3_@types+node@20.10.4/node_modules/vitest/dist/vendor/reporters.pr8MinP9.js',
>     time: 211.46663
>   },
>   { name: '(program)', time: 36.100577 },
>   { name: '(idle)', time: 29.876841 },
>   { name: '(garbage collector)', time: 13.79324 },
>   {
>     name: 'isWide at file:///home/runner/work/reporters-large/reporters-large/node_modules/.pnpm/vitest@1.0.3_@types+node@20.10.4/node_modules/vitest/dist/vendor/reporters.pr8MinP9.js',
>     time: 13.430992
>   }
> ]
> ```


`vitest@1.0.4` with fix:

```
> Tests took 28.944576
> Top 5 slowest functions [
>   { name: '(idle)', time: 9.227659 },
>   {
>     name: 'getFiles at file:///home/runner/work/reporters-large/reporters-large/node_modules/.pnpm/vitest@1.0.4_@types+node@20.10.4/node_modules/vitest/dist/vendor/node.vEetZgP7.js',
>     time: 2.565586
>   },
>   {
>     name: 'exec at file:///home/runner/work/reporters-large/reporters-large/node_modules/.pnpm/vitest@1.0.4_@types+node@20.10.4/node_modules/vitest/dist/vendor/node.vEetZgP7.js',
>     time: 1.859462
>   },
>   {
>     name: 'sliceAnsi at file:///home/runner/work/reporters-large/reporters-large/node_modules/.pnpm/vitest@1.0.4_@types+node@20.10.4/node_modules/vitest/dist/vendor/reporters.r0gTYN3L.js',
>     time: 1.800119
>   },
>   { name: '(program)', time: 0.87628 }
> ]
```
