### PR TITLE
feat: add `vitest-dev/vscode`

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -32,6 +32,7 @@ on:
           - nuxt
           - nuxt-test-utils
           - vite
+          - vitest-vscode
           - vitest-sonar-reporter
           - vitest-github-actions-reporter
           - vitest-browser-simple
@@ -100,6 +101,7 @@ jobs:
           - nuxt
           - nuxt-test-utils
           - vite
+          - vitest-vscode
           - vitest-sonar-reporter
           - vitest-github-actions-reporter
           - vitest-browser-simple

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -62,7 +62,6 @@ jobs:
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile
       - run: >-
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24'
           pnpm tsx ecosystem-ci.ts
           --${{ inputs.refType }} ${{ inputs.ref }}
           --repo ${{ inputs.repo }}

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -62,6 +62,7 @@ jobs:
       - run: pnpm --version
       - run: pnpm i --frozen-lockfile
       - run: >-
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24'
           pnpm tsx ecosystem-ci.ts
           --${{ inputs.refType }} ${{ inputs.ref }}
           --repo ${{ inputs.repo }}

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -37,6 +37,7 @@ on:
           - nuxt
           - nuxt-test-utils
           - vite
+          - vitest-vscode
           - vitest-sonar-reporter
           - vitest-github-actions-reporter
           - vitest-browser-simple

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -43,6 +43,7 @@ jobs:
           - nuxt
           - nuxt-test-utils
           - vite
+          - vitest-vscode
           - vitest-sonar-reporter
           - vitest-github-actions-reporter
           - vitest-browser-simple

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -10,7 +10,7 @@ export async function test(options: RunOptions) {
 		test: async () => {
 			// use execa directly since utils' wrapper seems to have problems with escaping
 			const { $: $_ } = await import('execa')
-			const $ = $_({ stdio: 'inherit', cwd })
+			const $ = $_({ stdio: 'inherit', verbose: true, cwd })
 			if (process.env.CI === 'true' && process.platform === 'linux') {
 				await $`xvfb-run --auto-servernum ${'--server-args=-screen 0 1920x1080x24'} pnpm test`
 			} else {

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -9,7 +9,7 @@ export async function test(options: RunOptions) {
 		repo: 'vitest-dev/vscode',
 		test: async () => {
 			if (process.env.CI === 'true' && process.platform === 'linux') {
-				await $`xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' pnpm test`
+				await $`xvfb-run --auto-servernum --server-args='-screen\\ 0\\ 1024x768x24' pnpm test`
 			} else {
 				await $`pnpm test`
 			}

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -6,18 +6,20 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		build: 'compile',
-		repo: 'vitest-dev/vscode',
+		// repo: 'vitest-dev/vscode',
+
+		// https://github.com/vitest-dev/vscode/pull/276
+		repo: 'hi-ogawa/vitest-vscode',
+		branch: 'test-vscode-e2e',
+
 		test: async () => {
 			if (process.env.CI === 'true' && process.platform === 'linux') {
 				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1920x1080x24 pnpm test`
+				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1920x1080x24 pnpm test-e2e`
 			} else {
 				await $`pnpm test`
+				await $`pnpm test-e2e`
 			}
 		},
-
-		// https://github.com/vitest-dev/vscode/pull/276
-		// repo: 'hi-ogawa/vitest-vscode',
-		// branch: 'test-vscode-e2e',
-		// test: ['test', 'test-e2e'],
 	})
 }

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -13,7 +13,7 @@ export async function test(options: RunOptions) {
 		test: async () => {
 			if (process.env.CI === 'true' && process.platform === 'linux') {
 				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1024x768x24 pnpm test`
-				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1024x768x24 pnpm test-e2e`
+				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1024x768x24 pnpm test-e2e --retry 2`
 			} else {
 				await $`pnpm test`
 				await $`pnpm test-e2e`

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -1,4 +1,4 @@
-import { runInRepo, cwd, $ } from '../utils'
+import { runInRepo, $ } from '../utils'
 import { RunOptions } from '../types'
 import process from 'node:process'
 

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -5,13 +5,11 @@ import process from 'node:process'
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		build: 'compile',
 		// repo: 'vitest-dev/vscode',
-
 		// https://github.com/vitest-dev/vscode/pull/276
 		repo: 'hi-ogawa/vitest-vscode',
 		branch: 'test-vscode-e2e',
-
+		build: 'compile',
 		test: async () => {
 			if (process.env.CI === 'true' && process.platform === 'linux') {
 				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1024x768x24 pnpm test`

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -1,0 +1,18 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+// npx tsx ecosystem-ci.ts vitest-vscode --release 1.3.1
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		build: 'compile',
+		repo: 'vitest-dev/vscode',
+		test: 'test',
+
+		// https://github.com/vitest-dev/vscode/pull/276
+		// repo: 'hi-ogawa/vitest-vscode',
+		// branch: 'test-vscode-e2e',
+		// test: ['test', 'test-e2e'],
+	})
+}

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -8,11 +8,12 @@ export async function test(options: RunOptions) {
 		build: 'compile',
 		repo: 'vitest-dev/vscode',
 		test: async () => {
-			if (process.env.CI === 'true' && process.platform === 'linux') {
-				await $`xvfb-run --auto-servernum --server-args='-screen\\ 0\\ 1024x768x24' pnpm test`
-			} else {
-				await $`pnpm test`
-			}
+			await $`pnpm test`
+			// if (process.env.CI === 'true' && process.platform === 'linux') {
+			// 	await $`xvfb-run --auto-servernum --server-args="-screen\\ 0\\ 1024x768x24" pnpm test`
+			// } else {
+			// 	await $`pnpm test`
+			// }
 		},
 
 		// https://github.com/vitest-dev/vscode/pull/276

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -14,8 +14,8 @@ export async function test(options: RunOptions) {
 
 		test: async () => {
 			if (process.env.CI === 'true' && process.platform === 'linux') {
-				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1920x1080x24 pnpm test`
-				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1920x1080x24 pnpm test-e2e`
+				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1024x768x24 pnpm test`
+				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1024x768x24 pnpm test-e2e`
 			} else {
 				await $`pnpm test`
 				await $`pnpm test-e2e`

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -1,14 +1,19 @@
-import { runInRepo } from '../utils'
+import { runInRepo, $ } from '../utils'
 import { RunOptions } from '../types'
-
-// npx tsx ecosystem-ci.ts vitest-vscode --release 1.3.1
+import process from 'node:process'
 
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		build: 'compile',
 		repo: 'vitest-dev/vscode',
-		test: 'test',
+		test: async () => {
+			if (process.env.CI === 'true' && process.platform === 'linux') {
+				await $`xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' pnpm test`
+			} else {
+				await $`pnpm test`
+			}
+		},
 
 		// https://github.com/vitest-dev/vscode/pull/276
 		// repo: 'hi-ogawa/vitest-vscode',

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -1,4 +1,4 @@
-import { runInRepo, cwd } from '../utils'
+import { runInRepo, cwd, $ } from '../utils'
 import { RunOptions } from '../types'
 import process from 'node:process'
 
@@ -8,11 +8,8 @@ export async function test(options: RunOptions) {
 		build: 'compile',
 		repo: 'vitest-dev/vscode',
 		test: async () => {
-			// use execa directly since utils' wrapper seems to have problems with escaping
-			const { $: $_ } = await import('execa')
-			const $ = $_({ stdio: 'inherit', verbose: true, cwd })
 			if (process.env.CI === 'true' && process.platform === 'linux') {
-				await $`xvfb-run --auto-servernum ${'--server-args=-screen 0 1920x1080x24'} pnpm test`
+				await $`xvfb-run --auto-servernum --server-args=-screen\\ 0\\ 1920x1080x24 pnpm test`
 			} else {
 				await $`pnpm test`
 			}

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -1,4 +1,4 @@
-import { runInRepo, $ } from '../utils'
+import { runInRepo, cwd } from '../utils'
 import { RunOptions } from '../types'
 import process from 'node:process'
 
@@ -8,12 +8,14 @@ export async function test(options: RunOptions) {
 		build: 'compile',
 		repo: 'vitest-dev/vscode',
 		test: async () => {
-			await $`pnpm test`
-			// if (process.env.CI === 'true' && process.platform === 'linux') {
-			// 	await $`xvfb-run --auto-servernum --server-args="-screen\\ 0\\ 1024x768x24" pnpm test`
-			// } else {
-			// 	await $`pnpm test`
-			// }
+			// use execa directly since utils' wrapper seems to have problems with escaping
+			const { $: $_ } = await import('execa')
+			const $ = $_({ stdio: 'inherit', cwd })
+			if (process.env.CI === 'true' && process.platform === 'linux') {
+				await $`xvfb-run --auto-servernum ${'--server-args=-screen 0 1920x1080x24'} pnpm test`
+			} else {
+				await $`pnpm test`
+			}
 		},
 
 		// https://github.com/vitest-dev/vscode/pull/276

--- a/tests/vitest-vscode.ts
+++ b/tests/vitest-vscode.ts
@@ -5,10 +5,7 @@ import process from 'node:process'
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		// repo: 'vitest-dev/vscode',
-		// https://github.com/vitest-dev/vscode/pull/276
-		repo: 'hi-ogawa/vitest-vscode',
-		branch: 'test-vscode-e2e',
+		repo: 'vitest-dev/vscode',
 		build: 'compile',
 		test: async () => {
 			if (process.env.CI === 'true' && process.platform === 'linux') {

--- a/utils.ts
+++ b/utils.ts
@@ -19,7 +19,7 @@ import * as semver from 'semver'
 const isGitHubActions = !!process.env.GITHUB_ACTIONS
 
 let vitestPath: string
-export let cwd: string
+let cwd: string
 let env: ProcessEnv
 
 const VITEST_SUB_PACKAGES = [

--- a/utils.ts
+++ b/utils.ts
@@ -19,7 +19,7 @@ import * as semver from 'semver'
 const isGitHubActions = !!process.env.GITHUB_ACTIONS
 
 let vitestPath: string
-let cwd: string
+export let cwd: string
 let env: ProcessEnv
 
 const VITEST_SUB_PACKAGES = [


### PR DESCRIPTION
This PR adds Vitest VS Code extension https://github.com/vitest-dev/vscode.

Little summary of the repo and tests:
- Currently extension has own modified version of `@vitest/ws-client` https://github.com/vitest-dev/vscode/blob/85aa7edfce24914bee6a849e61d935e8f0b97bb2/src/pure/watch/ws-client.ts and uses it to communicate with Vitest CLI spawned by `--api` (though this might change in the future by https://github.com/vitest-dev/vscode/pull/253)
- `pnpm test` (added in https://github.com/vitest-dev/vscode/pull/262) only tests internal utilities, so it doesn't really exercise Vitest feature.
- `pnpm test-e2e` (will be added in https://github.com/vitest-dev/vscode/pull/276) runs a simple sample with extensions, so this will exercise both extension's ws-client implementation and Vitest CLI.

I think we can wait this PR until E2E is setup on vscode extension repo, but I just wanted to explore ecosystem-ci beforehand.
