### PR TITLE
fix: add new `@vitest/pretty-format` sub package

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -34,6 +34,7 @@ const VITEST_SUB_PACKAGES = [
 	'spy',
 	'utils',
 	'ws-client',
+	'pretty-format',
 ]
 
 function cd(dir: string) {


### PR DESCRIPTION
- Ref. https://github.com/vitest-dev/vitest/pull/6077
- Fixes https://github.com/vitest-dev/vitest-ecosystem-ci/actions/runs/9902779978

> ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In : "@vitest/pretty-format@workspace:^" is in the dependencies but no package named "@vitest/pretty-format" is present in the workspace
>This error happened while installing the dependencies of vitest@2.0.2

