### PR TITLE
feat: add Lerna-Lite ecosystem test

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -34,6 +34,7 @@ on:
           - nuxt-test-utils
           - elk
           - effect
+          - lerna-lite
           - zustand
           - vue
           - vite
@@ -107,6 +108,7 @@ jobs:
           - nuxt-test-utils
           - elk
           - effect
+          - lerna-lite
           - zustand
           - vue
           - vite

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -39,6 +39,7 @@ on:
           - nuxt-test-utils
           - elk
           - effect
+          - lerna-lite
           - zustand
           - vue
           - vite

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -45,6 +45,7 @@ jobs:
           - nuxt-test-utils
           - elk
           - effect
+          - lerna-lite
           - zustand
           - vue
           - vite

--- a/tests/lerna-lite.ts
+++ b/tests/lerna-lite.ts
@@ -6,6 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'lerna-lite/lerna-lite',
 		test: 'pnpm test',
-    build: 'build',
+		build: 'build',
 	})
 }

--- a/tests/lerna-lite.ts
+++ b/tests/lerna-lite.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'lerna-lite/lerna-lite',
+		test: 'pnpm test',
+    build: 'build',
+	})
+}


### PR DESCRIPTION
adding Lerna-Lite as a suite of tests to run, @AriPerkkio already knows the repo since he contributed in the past. Lerna-Lite uses a lot of `child_process` and a few snapshot serializers, it previously required `--no-thread` with Vitest 1.x but is now using `pool: 'forks'`. I use Renovate on a regular basis, it runs every 2 weeks, to keep all deps up to date. So I think it could be a good addition for the ecosystem tests. Cheers

Here's a good Vitest reference of when Lerna-Lite was mentioned 
[feat!: support multiple parallel child_process](https://github.com/vitest-dev/vitest/pull/3925)

Side note, I'm not sure how to execute the tests, so I setup it up with the best of my knowledge though I'm not sure 100% 