### PR TITLE
feat: add sveltejs-cli to test sveltekit

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -38,6 +38,7 @@ on:
           - effect
           - lerna-lite
           - zustand
+          - sveltejs-cli
           - vue
           - vite
           - vitest-vscode
@@ -111,6 +112,7 @@ jobs:
           - effect
           - lerna-lite
           - zustand
+          - sveltejs-cli
           - vue
           - vite
           - vitest-vscode

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -43,6 +43,7 @@ on:
           - effect
           - lerna-lite
           - zustand
+          - sveltejs-cli
           - vue
           - vite
           - vitest-vscode

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -49,6 +49,7 @@ jobs:
           - effect
           - lerna-lite
           - zustand
+          - sveltejs-cli
           - vue
           - vite
           - vitest-vscode

--- a/tests/sveltejs-cli.ts
+++ b/tests/sveltejs-cli.ts
@@ -1,0 +1,11 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'sveltejs/cli',
+		build: 'build',
+		test: 'pnpm exec vitest --project addons vitest',
+	})
+}


### PR DESCRIPTION
It looks like they have test suites for sveltekit, so I added it here as ecosystem ci. We can remove https://github.com/vitest-dev/vitest/tree/main/examples/sveltekit (https://github.com/vitest-dev/vitest/pull/7767) in favor of this.

Here is a local run:

```
$ pnpm test sveltejs-cli
...

/home/hiroshi/code/others/vitest-ecosystem-ci/workspace/sveltejs-cli/cli $> pnpm exec vitest --project addons vitest

 RUN  v3.1.0-beta.2 /home/hiroshi/code/others/vitest-ecosystem-ci/workspace/sveltejs-cli/cli

 ✓  addons  _tests/vitest/test.ts (4 tests) 20036ms
   ✓ core - kit-js  19683ms
   ✓ core - kit-ts  19668ms
   ✓ core - vite-js  19664ms
   ✓ core - vite-ts  19987ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  14:12:24
   Duration  23.02s (transform 723ms, setup 0ms, collect 572ms, tests 20.04s, environment 0ms, prepare 51ms)
```