### PR TITLE
feat: add `@webcontainer/test`

### DIFF
--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -46,6 +46,7 @@ on:
           - vitest-reporters-large
           - vitest-benchmark-large
           - vitest-pool-workers
+          - webcontainer-test
 
 jobs:
   init:
@@ -126,6 +127,7 @@ jobs:
           - vitest-coverage-large
           - vitest-reporters-large
           - vitest-benchmark-large
+          - webcontainer-test
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -51,6 +51,8 @@ on:
           - vitest-reporters-large
           - vitest-benchmark-large
           - vitest-pool-workers
+          - webcontainer-test
+
 jobs:
   execute-selected-suite:
     timeout-minutes: 60

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -58,6 +58,7 @@ jobs:
           - vitest-reporters-large
           - vitest-benchmark-large
           - vitest-pool-workers
+          - webcontainer-test
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/tests/webcontainer-test.ts
+++ b/tests/webcontainer-test.ts
@@ -1,0 +1,14 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: 'stackblitz/webcontainer-test',
+		branch: 'main',
+		build: 'build',
+		test: 'test',
+		beforeTest:
+			'npx playwright install chromium firefox --with-deps --only-shell',
+	})
+}


### PR DESCRIPTION
- Adds https://github.com/stackblitz/webcontainer-test to ecosystem
- `@webcontainer/test` uses:
  - Chrome + Firefox on browser mode
  - Custom browser commands
  - Extensive fixture usage
  - Custom Vite plugins

