### PR TITLE
fix: remove `@vitest/runner` sub package

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -32,7 +32,6 @@ const VITEST_SUB_PACKAGES = [
 	'expect',
 	'mocker',
 	'pretty-format',
-	'runner',
 	'snapshot',
 	'spy',
 	'ui',


### PR DESCRIPTION
CI failing with `ENOENT  ENOENT: no such file or directory, open '/home/runner/work/vitest-ecosystem-ci/vitest-ecosystem-ci/workspace/vitest/packages/runner/vitest-runner-5.0.0-beta.4.tgz'` after https://github.com/vitest-dev/vitest/pull/10511