### PR TITLE
fix: disable pnpm `allowBuilds`

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -555,6 +555,7 @@ export async function applyPackageOverrides(
 
 	// use of `ni` command here could cause lockfile violation errors so fall back to native commands that avoid these
 	if (pm === 'pnpm') {
+		await $`pnpm config set dangerouslyAllowAllBuilds true`
 		await $`pnpm install --prefer-frozen-lockfile --prefer-offline --strict-peer-dependencies false`
 	} else if (pm === 'yarn') {
 		await $`yarn install`


### PR DESCRIPTION
Fix packages that fail with:

```
  [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: edgedriver@6.3.0, geckodriver@6.1.0
  
  Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```
